### PR TITLE
Tambah penerangan tentang environment variables ketika pemasangan pelayan.

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,6 +46,13 @@ menggunakan keperluan yang sudah dijelaskan dalam fail `pyproject.toml`)
 $ poetry run python ./samudra/serve.py
 ```
 
+Jika anda menerima ralat mengenai ACCESS\_TOKEN\_EXPIRE\_MINUTES, ia adalah kerana environment variables tidak ditetapkan dengan betul. Masalah ini boleh dibetulkan dengan menetapkan environment variables yang betul semasa memulakan pelayan, contohnya:  
+
+```shell
+$ ACCESS_TOKEN_EXPIRE_MINUTES=60 poetry run python ./samudra/serve.py
+```
+
+
 ### Menyumbang kod
 
 1. Buat cabang baharu agar setiap perubahan tersebut tidak mengganggu cabang utama. Namakan cabang secara deskriptif (

--- a/README.md
+++ b/README.md
@@ -36,6 +36,38 @@ serta satu perkataan boleh dipadankan ke banyak kata asing yang bergantung pada 
    $ poetry install
    ```
 
+### Sediakan fail .env
+
+Sebelum boleh memulakan pelayan, fail `.env` perlu wujud untuk menyediakan nilai yang berlainan bagi setiap salinan
+aplikasi. Fail ini terletak dalam ROOT, iaitu tempat yang sama wujudnya `README.md` ini.
+Biasanya, nilai-nilai yang diletakkan dalam ini adalah nilai-nilai rahsia yang tidak boleh dikomit masuk git.
+Berikut merupakan nilai-nilai yang perlu ada dalam fail `.env` samudra:
+
+```shell
+# ./.env
+
+# Buat masa sekarang ada tiga enjin: SQLite, MySQL, dan CockroachDB.
+# SQLite sesuai untuk aplikasi lokal dan hanya satu pengguna.
+# Yang lain memerlukan pelayan
+ENGINE = SQLite
+
+# Yang ini adalah nilai yang diperlukan untuk daftar masuk pelayan DB
+# (Tidak perlu kalau pilih enjin SQLite)
+DATABASE_USERNAME = 
+DATABASE_PASSWORD = 
+
+# Maklumat pelayan DB
+# (Tidak perlu kalau pilih enjin SQLite)
+DATABASE_NAME = 
+DATABASE_HOST = 
+DATABASE_PORT = 
+DATABASE_OPTIONS = 
+
+# Tempoh masa pengguna dibenarkan log masuk (dalam sukatan minit)
+# (Wajib walaupun pilih enjin SQLite)
+ACCESS_TOKEN_EXPIRE_MINUTES = 
+```
+
 ### Mulakan pelayan
 
 Setelah selesai langkah pemasangan, mulakan pelayan menggunakan poetry
@@ -46,12 +78,9 @@ menggunakan keperluan yang sudah dijelaskan dalam fail `pyproject.toml`)
 $ poetry run python ./samudra/serve.py
 ```
 
-Jika anda menerima ralat mengenai ACCESS\_TOKEN\_EXPIRE\_MINUTES, ia adalah kerana environment variables tidak ditetapkan dengan betul. Masalah ini boleh dibetulkan dengan menetapkan environment variables yang betul semasa memulakan pelayan, contohnya:  
-
-```shell
-$ ACCESS_TOKEN_EXPIRE_MINUTES=60 poetry run python ./samudra/serve.py
-```
-
+Jika anda menerima ralat mengenai nilai-nilai yang tidak tertakrif, rujuk bahagian [fail .env](#Sediakan fail .env).
+Lihat sekiranya nilai-nilai yang tersenarai di situ sudah tertakrif belum.
+Sekiranya nilai ralat itu tidak disenaraikan, boleh failkan isu.
 
 ### Menyumbang kod
 

--- a/docs/pemasangan.md
+++ b/docs/pemasangan.md
@@ -19,7 +19,40 @@ $ cd samudra
 $ poetry install
 ```
 
-## Mulakan pelayan
+### Sediakan fail .env
+
+Sebelum boleh memulakan pelayan, fail `.env` perlu wujud untuk menyediakan nilai yang berlainan bagi setiap salinan
+aplikasi. Fail ini terletak dalam ROOT, iaitu tempat yang sama wujudnya `pyproject.toml`.
+Biasanya, nilai-nilai yang diletakkan dalam ini adalah nilai-nilai rahsia yang tidak boleh dikomit masuk git.
+
+Berikut merupakan nilai-nilai yang perlu ada dalam fail `.env` samudra:
+
+```shell
+# ./.env
+
+# Buat masa sekarang ada tiga enjin: SQLite, MySQL, dan CockroachDB.
+# SQLite sesuai untuk aplikasi lokal dan hanya satu pengguna.
+# Yang lain memerlukan pelayan
+ENGINE = SQLite
+
+# Yang ini adalah nilai yang diperlukan untuk daftar masuk pelayan DB
+# (Tidak perlu kalau pilih enjin SQLite)
+DATABASE_USERNAME = 
+DATABASE_PASSWORD = 
+
+# Maklumat pelayan DB
+# (Tidak perlu kalau pilih enjin SQLite)
+DATABASE_NAME = 
+DATABASE_HOST = 
+DATABASE_PORT = 
+DATABASE_OPTIONS = 
+
+# Tempoh masa pengguna dibenarkan log masuk (dalam sukatan minit)
+# (Wajib walaupun pilih enjin SQLite)
+ACCESS_TOKEN_EXPIRE_MINUTES = 
+```
+
+### Mulakan pelayan
 
 Setelah selesai langkah pemasangan, mulakan pelayan menggunakan poetry
 (poetry digunakan bagi memastikan arahan dalam fail python dilaksanakan
@@ -29,9 +62,7 @@ menggunakan keperluan yang sudah dijelaskan dalam fail `pyproject.toml`)
 $ poetry run python ./samudra/serve.py
 ```
 
-Jika anda menerima ralat mengenai ACCESS\_TOKEN\_EXPIRE\_MINUTES, ia adalah kerana environment variables tidak ditetapkan dengan betul. Masalah ini boleh dibetulkan dengan menetapkan environment variables yang betul semasa memulakan pelayan, contohnya:  
-
-```shell
-$ ACCESS_TOKEN_EXPIRE_MINUTES=60 poetry run python ./samudra/serve.py
-```
+Jika anda menerima ralat mengenai nilai-nilai yang tidak tertakrif, rujuk bahagian [fail .env](#Sediakan fail .env).
+Lihat sekiranya nilai-nilai yang tersenarai di situ sudah tertakrif belum.
+Sekiranya nilai ralat itu tidak disenaraikan, boleh failkan isu.
 

--- a/docs/pemasangan.md
+++ b/docs/pemasangan.md
@@ -28,3 +28,10 @@ menggunakan keperluan yang sudah dijelaskan dalam fail `pyproject.toml`)
 ```shell
 $ poetry run python ./samudra/serve.py
 ```
+
+Jika anda menerima ralat mengenai ACCESS\_TOKEN\_EXPIRE\_MINUTES, ia adalah kerana environment variables tidak ditetapkan dengan betul. Masalah ini boleh dibetulkan dengan menetapkan environment variables yang betul semasa memulakan pelayan, contohnya:  
+
+```shell
+$ ACCESS_TOKEN_EXPIRE_MINUTES=60 poetry run python ./samudra/serve.py
+```
+


### PR DESCRIPTION
Pelayan ketika ini sebenarnya memerlukan environment variables untuk berfungsi dengan betul. Akan tetapi, tiada penerangan tentang menetapkan environment variables di `README.md`.

### Untuk siapa perubahan ini?
Perubahan ini untuk memudahkan penyumbang baharu yang tidak berapa memahami python, poetry atau sistem operasi secara tetap.

### Adakah perubahan ini menyelesaikan masalah?
Secara jujurnya, tidak. Seperti dinyatakan di atas, ini hanyalah untuk memudahkan penyumbang baharu sementara fungsi lain yang lebih penting diselesaikan terlebih dahulu. Rasanya menetapkan nilai lalai boleh menyelesaikan masalah ini, tetapi saya mahu fokus pada fungsi lain terlebih dahulu.